### PR TITLE
Compile book automatically with GitHub Actions

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -1,0 +1,27 @@
+name: Build LaTeX document
+on: [push, pull_request]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        continue-on-error: true
+        with:
+          root_file: da2020.tex
+          working_directory: ./book
+          args: -f -interaction=nonstopmode
+      - name: Upload LaTeX document to artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: PDF
+          path: ./book/da2020.pdf
+      - name: Serve LaTeX document
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Online textbook by Juho Hirvonen and Jukka Suomela.
 This repository contains the full source code of the textbook, and
 the source material used to prepare the lecture slides and videos.
 
+Latest version is compiled automatically to the branch [`gh-pages`](https://github.com/suomela/da2020/blob/gh-pages/da2020.pdf).
+
 For more information, see:
 https://jukkasuomela.fi/da2020/
 


### PR DESCRIPTION
This PR implements a GitHub Actions workflow that compiles the book with `latexmk`.

The book is compiled for all pushes and pull requests and is downloadable from GitHub Action artifacts.

If the branch is main (`${{ github.ref == 'refs/heads/main' }}`), the compiled book is also saved to the `gh-pages` branch, from which the book can be fetched from https://github.com/suomela/da2020/blob/gh-pages/da2020.pdf. This is linked to the README.